### PR TITLE
🚧wip (dart) Disable `%` in line-items for t&m tasks

### DIFF
--- a/systori/dart/lib/src/editor/editor.dart
+++ b/systori/dart/lib/src/editor/editor.dart
@@ -706,11 +706,10 @@ class LineItem extends Model with Orderable, Row, HtmlRow, KeyboardHandler {
     @override
     bool onKeyUpEvent(event, input) {
       final isTandM = (parent.parent as Task).is_time_and_materials.value;
-      final trigger = new String.fromCharCode(event.keyCode);
-      final isUnit = input.name == 'unit';
+      final isUnit = input.name==unit.name;
 
-      if (isUnit && trigger == '%' && isTandM) {
-        input.text.replaceAll('%', '');
+      if (isUnit && hasPercent && isTandM) {
+        unit.text = unit.text.replaceAll('%','');
         return true;
       }
       return false;

--- a/systori/dart/lib/src/editor/editor.dart
+++ b/systori/dart/lib/src/editor/editor.dart
@@ -704,6 +704,19 @@ class LineItem extends Model with Orderable, Row, HtmlRow, KeyboardHandler {
     }
 
     @override
+    bool onKeyUpEvent(event, input) {
+      final isTandM = (parent.parent as Task).is_time_and_materials.value;
+      final trigger = new String.fromCharCode(event.keyCode);
+      final isUnit = input.name == 'unit';
+
+      if (isUnit && trigger == '%' && isTandM) {
+        input.text.replaceAll('%', '');
+        return true;
+      }
+      return false;
+    }
+
+    @override
     bool onInputEvent(Input input) {
         if (input.name == 'is_hidden') {
             onCalculate('hidden', total);


### PR DESCRIPTION
This should be reverted as soon as #378 is merged

See #376 for details