### PR TITLE
🔧conf (vscode) Add chrome debug config for `ts`

### DIFF
--- a/systori/static/ts/.vscode/launch.json
+++ b/systori/static/ts/.vscode/launch.json
@@ -17,7 +17,7 @@
     ],
     "inputs": [
         {
-            "id": "comapany-schema",
+            "id": "company-schema",
             "type": "promptString",
             "default": "demo",
             "description": "Systori company schema"

--- a/systori/static/ts/.vscode/launch.json
+++ b/systori/static/ts/.vscode/launch.json
@@ -1,0 +1,26 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "chrome",
+            "request": "launch",
+            "name": "Launch Chrome",
+            "preLaunchTask": "npm: webpack",
+            "url": "http://${input:company-schema}.systori.localhost",
+            "webRoot": "${workspaceFolder}",
+            "showAsyncStacks": true,
+            "userDataDir": true
+        }
+    ],
+    "inputs": [
+        {
+            "id": "comapany-schema",
+            "type": "promptString",
+            "default": "demo",
+            "description": "Systori company schema"
+        }
+    ]
+}

--- a/systori/static/ts/.vscode/tasks.json
+++ b/systori/static/ts/.vscode/tasks.json
@@ -1,0 +1,22 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "type": "npm",
+            "script": "webpack",
+            "isBackground": true,
+            "presentation": {
+                "echo": true,
+                "reveal": "silent",
+                "focus": false,
+                "panel": "shared",
+                "showReuseMessage": true,
+                "clear": false
+            },
+            "group": "build",
+            "problemMatcher": []
+        }
+    ]
+}


### PR DESCRIPTION
Launching the config for the first time will show a warning from vscode, this is due to the fact
that webpack runs in watch mode and vscode expects to capture it's output and return any problems.
This warning can safely be ignored by clicking "Debug anyway"